### PR TITLE
Add working directory input variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,15 @@ inputs:
   source:
     description: Sources to zip
     required: true
+  working-directory:
+    description: Working directory to run the container in
+    required: false
+    default: "."
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - "-r ${{ inputs.target }} ${{ inputs.source }} ${{ inputs.args }}"
+    - "{{ inputs.working-directory }}"
 

--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ runs:
   image: 'Dockerfile'
   args:
     - "-r ${{ inputs.target }} ${{ inputs.source }} ${{ inputs.args }}"
-    - "{{ inputs.working-directory }}"
+    - {{ inputs.working-directory }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-cd /github/workspace
+cd /github/workspace/$2
 ls -la
 deterministic-zip $1


### PR DESCRIPTION
## Description
Include a `working-directory` input (mirroring the naming used by shell actions) that sets the working directory to run the ZIP in.

Addresses the following issue: Say I have a repository that looks like:

```
| file0
+- folder1
+| file1
+| file2
```

Running the action with 
```yaml
- source: folder1
- target: ...
```
ends up including `folder1` in the ZIP. But I need only `file1` and `file2`.

