### PR TITLE
Fix Dockerfile license labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# License: mit
+LABEL org.opencontainers.image.licenses="mit"
+
 FROM busybox
 COPY --from=timoreymann/deterministic-zip:latest /bin/deterministic-zip /bin/deterministic-zip
 COPY ./entrypoint.sh /entrypoint


### PR DESCRIPTION

            This PR fixes the `org.opencontainers.image.licenses` labels in Dockerfiles to match the repository license (mit).
            
            Changes made:
            - ✅ Addd license label in `Dockerfile`

Repository license: `mit`